### PR TITLE
Release 0.1.2 - Increase Variable Set limit from 20 to 100

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Spaces in the variable set name are replaced with hyphens (`-`).
 
 ## Restrictions
 The code assumes that all of the Terraform Cloud Variable Sets are contained
-within the first result page of 20 entries.
+within the first result page of 100 entries.
 
 ## Docker Hub
 This image is built automatically on Docker Hub as [silintl/tfc-backup-b2](https://hub.docker.com/r/silintl/tfc-backup-b2/)


### PR DESCRIPTION
### Changed

* By default, the list of Variable Sets is limited to 20.  The limit has been increased to 100.  An error message is printed if there are more than 100 Variable Sets to be backed up.  Only the first 100 Variable Sets are backed up.

### Reference

* https://developer.hashicorp.com/terraform/cloud-docs/api-docs/variable-sets#list-variable-sets
* ITSE-758